### PR TITLE
Tiny index fix

### DIFF
--- a/lecture3/pmpp.ipynb
+++ b/lecture3/pmpp.ipynb
@@ -962,7 +962,7 @@
     "    for i0 in range(blocks.y):\n",
     "        for i1 in range(blocks.x):\n",
     "            for j0 in range(threads.y):\n",
-    "                for j1 in range(threads.x): f(ns(x=i0,y=i1), ns(x=j0,y=j1), threads, *args)"
+    "                for j1 in range(threads.x): f(ns(x=i1,y=i0), ns(x=j1,y=j0), threads, *args)"
    ]
   },
   {


### PR DESCRIPTION
Fix the indices typo.
If tpb.x = tbp.y and blocks.x = blocks.y wrt the following code from `def matmul_2d(m, n):`
```
    tpb = ns(x=16,y=16)
    blocks = ns(x=math.ceil(w/tpb.x), y=math.ceil(h/tpb.y))
```

then the original way gives the correct result (otherwise not).