### PR TITLE
fix: update environment setup for session 4

### DIFF
--- a/lecture4/cuda-mode-session-4.ipynb
+++ b/lecture4/cuda-mode-session-4.ipynb
@@ -12,6 +12,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "3fd3f4aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install ninja\n",
+    "!sudo apt update\n",
+    "!sudo apt install g++-11 -y\n",
+    "!sudo apt install ccache -y"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 17,
    "id": "63b545e7",
    "metadata": {},


### PR DESCRIPTION
Added a new cell for the environment setup as part of running this in google colab:
- `ninja`: Required for PyTorch's extension loader.
- `g++-11`: Set as the C++ compiler in environment variables for CUDA extension compilation.
- `ccache`: Configured for `g++` and `gcc` to improve compile times in interactive development environments like Colab.
